### PR TITLE
Do not send Content-Type header on GET/HEAD requests to signhost

### DIFF
--- a/src/SignhostClient.php
+++ b/src/SignhostClient.php
@@ -85,6 +85,12 @@ class SignhostClient
                 $headers[]  = 'Digest: SHA256=' . base64_encode(pack('H*', hash_file('sha256', $filePath)));
             }
 
+            // If method is a GET or HEAD request, unset the Content-Type headers if filePath is not given
+            // GET/HEAD methods never have a content Type
+            if ("GET" === $method || "HEAD" === $method && !isset($filePath)) {
+                unset($headers[0]); // unset Content-Type
+            }
+            
             // Initialize a cURL session
             return $this->performCURLRequest(
                 $method,


### PR DESCRIPTION
Do not send the Content-Type on GET/HEAD requests